### PR TITLE
Add registered prop to app.src for compat with relx

### DIFF
--- a/src/lager_logstash.app.src
+++ b/src/lager_logstash.app.src
@@ -1,5 +1,6 @@
 {application, lager_logstash,
  [{description, "Logstash backend for Lager"},
   {vsn, "0.1.2"},
+  {registered,[]},
   {applications, [kernel,
                   stdlib]}]}.


### PR DESCRIPTION
Avoids errors in relx as follows:

Errors generating release
          lager_logstash: Missing parameter in .app file: registered
