### PR TITLE
Workaround jsx not liking atom values

### DIFF
--- a/src/lager_logstash_json_formatter.erl
+++ b/src/lager_logstash_json_formatter.erl
@@ -56,6 +56,8 @@ convert({pid, Pid}, Acc) when is_pid(Pid) ->
     [{pid, list_to_binary(pid_to_list(Pid))} | Acc];
 convert({K, List}, Acc) when is_list(List) ->
     [{K, iolist_to_binary(List)} | Acc];
+convert({K, Atom}, Acc) when is_atom(Atom) ->
+    [{K, atom_to_binary(Atom, latin1)} | Acc];
 convert(Else, Acc) -> [Else | Acc].
 
 encode(jsx, Data)   -> jsx:encode(Data);


### PR DESCRIPTION
3> jsx:encode([{node,'something@127.0.0.1'}]).
*\* exception error: bad argument
